### PR TITLE
Fix failing test for workflow header

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the workflow header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Lincoln University Admission Workflow Tool/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update sample test to check for the actual workflow heading

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840d484c020832d9ff67f8de14cd5c9